### PR TITLE
Fix: 유저가 선택한 카테고리 알고리즘 수정

### DIFF
--- a/src/main/java/com/starters/ityogurt/config/EmailConfig.java
+++ b/src/main/java/com/starters/ityogurt/config/EmailConfig.java
@@ -44,7 +44,7 @@ public class EmailConfig {
 
     //이메일 전송 API
     // @RequestMapping("/aws/email")
-    @Scheduled(cron = "0 31 14 * * ?", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 53 14 * * ?", zone = "Asia/Seoul")
     public String sendEmail() throws Exception {
         // 유저의 이메일과 유저가 선택한 소분류를 map에 담은 것을 반환한다.
         List<Map<String, Object>> subEmailMap = emailService.getEmailAndSub();
@@ -102,11 +102,7 @@ public class EmailConfig {
 
         // 예외처리 해야 함 : 카테고리 18번에 퀴즈가 없다.
         categoryMap.forEach((key, value) -> {
-            System.out.println(value);
             KnowledgeDTO knowledgeDTO = knowledgeService.getKnowledgeByCategorySeq(value);
-            System.out.println(knowledgeDTO);
-            System.out.println("getQuiz()" + quizService.getQuiz(17));
-            System.out.println("getQuiz()" + quizService.getQuiz(17).size());
             emailService.send("오늘의 지식은 " + knowledgeDTO.getTitle() + "이야!",
                     headerText() + knowledgeDTO.getContent() + buttonText(knowledgeDTO.getKnowSeq()) + footerText(),
                     (List<String>) subEmailList.get(key));
@@ -154,14 +150,5 @@ public class EmailConfig {
                 "</div>";
         return footerText;
     }
-
-    @GetMapping("user/email")
-    public String checkEmail(String email) {
-        userService.setIsPassByUserSeq(31);
-        return "true";
-    }
-
-
-
 }
 

--- a/src/main/java/com/starters/ityogurt/controller/UserController.java
+++ b/src/main/java/com/starters/ityogurt/controller/UserController.java
@@ -11,6 +11,7 @@ import org.apache.ibatis.jdbc.Null;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,9 +39,12 @@ public class UserController {
         return "user/signUp";
     }
 
-    @GetMapping("/user/check/{quizSeq}")
-    public String QuizLoginCheck(@PathVariable(value = "quizSeq") int quizSeq) {
-        return "user/check";
+    @GetMapping("/user/check/{knowSeq}")
+    public ModelAndView QuizLoginCheck(@PathVariable(value = "knowSeq") int knowSeq) {
+        ModelAndView mv = new ModelAndView();
+        mv.addObject("knowSeq", knowSeq);
+        mv.setViewName("user/check");
+        return mv;
     }
 
     // 이메일 인증 페이지

--- a/src/main/resources/mybatis/mapper/email-mapping.xml
+++ b/src/main/resources/mybatis/mapper/email-mapping.xml
@@ -26,11 +26,16 @@
         ORDER BY SUB
     </select>
 
+<!--    <select id="getSendDetail" parameterType="int" resultType="Map">-->
+<!--        SELECT sub, category_seq-->
+<!--        FROM category-->
+<!--        WHERE (sub, send_date) IN (SELECT sub, MIN(send_date) FROM category where detail IS NOT NULL GROUP BY sub ORDER BY category_seq)-->
+<!--        order BY send_date, category_seq-->
+<!--    </select>-->
     <select id="getSendDetail" parameterType="int" resultType="Map">
         SELECT sub, category_seq
-        FROM category
-        WHERE (sub, send_date) IN (SELECT sub, MIN(send_date) FROM category where detail IS NOT NULL GROUP BY sub ORDER BY category_seq)
-        order BY send_date, category_seq
+        FROM (SELECT sub, category_seq, send_date, ROW_NUMBER() over(PARTITION BY sub ORDER BY send_date, category_seq) AS num FROM category WHERE detail IS NOT NULL) AS imsi
+        WHERE num=1;
     </select>
 
 

--- a/src/main/webapp/WEB-INF/views/index1.jsp
+++ b/src/main/webapp/WEB-INF/views/index1.jsp
@@ -47,7 +47,7 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarResponsive">
             <ul class="navbar-nav ms-auto">
-                <li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded" href="<%=request.getContextPath()%>/list2/1">매일지식</a></li>
+                <li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded" href="<%=request.getContextPath()%>/knowledge/list">매일지식</a></li>
                 <li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded" href="<%=request.getContextPath()%>/board/list">Quiz</a></li>
                 <li class="nav-item mx-0 mx-lg-1"><a class="nav-link py-3 px-0 px-lg-3 rounded" href="#mypage">MyPage</a></li>
             </ul>


### PR DESCRIPTION
**변경사항**

1. 소분류 카테고리 밑의 상세정보 카테고리 조회 알고리즘을 수정
기존 로직은 MIN(send_date)를 사용했기에 동일 날짜가 있다면 원하는 결과가 나오지 않았습니다. 서브쿼리/partition by/ROW_NUM()을 사용하여 각 카테고리별 가장 오래되고 작은 카테고리 숫자 하나만을 가진 상세정보가 조회될 수 있도록 변경했습니다. 

2. 퀴즈 유무에 따른 이메일 내부 버튼의 차이점 구현
카테고리에 퀴즈가 없을 경우 정보글을 볼 수 있도록, 퀴즈가 있는 경우는 퀴즈 확인 화면으로 이동할 수 있도록 IF문을 사용하여 구현했습니다.